### PR TITLE
Add audio device selection to media player GUI 

### DIFF
--- a/source/gui/settings_dialog.py
+++ b/source/gui/settings_dialog.py
@@ -413,7 +413,15 @@ class SettingsDialog(wx.Dialog):
 		selected_device_id = self.device_map[self.deviceBox.Selection]
 		if not selected_device_id == config_get("audio_device"):
 			config_set("audio_device", selected_device_id)
-			restart = True # Changing audio device requires restart or re-init of player, restart is safest for global effect
+			# restart = True # Changing audio device requires restart or re-init of player, restart is safest for global effect
+			
+			# Apply immediately if possible
+			try:
+				parent = self.GetParent()
+				if parent and hasattr(parent, 'player') and parent.player:
+					parent.player.set_audio_output_device(selected_device_id)
+			except Exception as e:
+				print(f"Failed to apply audio device immediately: {e}")
 			
 		config_set("defaultformat", self.formats.Selection) if not self.formats.Selection == int(config_get('defaultformat')) else None
 		

--- a/source/media_player/media_gui.py
+++ b/source/media_player/media_gui.py
@@ -224,8 +224,10 @@ class MediaGui(wx.Frame):
 		self.nextButton = CustomButton(self.mainPanel, -1, _("Next Video"), name="controls")
 		self.nextButton.Show() if self.results is not None else self.nextButton.Hide()
 		
+
 		self.speedButton = CustomButton(self.mainPanel, -1, _("Speed"), name="controls")
 		self.audioTrackBtn = CustomButton(self.mainPanel, -1, _("Audio Track"), name="controls")
+		self.audioDeviceBtn = CustomButton(self.mainPanel, -1, _("Audio Device"), name="controls")
 
 		# Toggles (Checkboxes)
 		self.chkRepeat = wx.CheckBox(self.mainPanel, -1, _("Repeat"))
@@ -259,6 +261,7 @@ class MediaGui(wx.Frame):
 		if self.results: self.controlsSizer.Add(self.nextButton, 1, wx.EXPAND)
 		self.controlsSizer.Add(self.speedButton, 1, wx.EXPAND)
 		self.controlsSizer.Add(self.audioTrackBtn, 1, wx.EXPAND)
+		self.controlsSizer.Add(self.audioDeviceBtn, 1, wx.EXPAND)
 		
 		self.controlsSizer.Add(self.chkRepeat, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
 
@@ -354,6 +357,7 @@ class MediaGui(wx.Frame):
 		self.browserBtn.Bind(wx.EVT_BUTTON, self.onBrowser)
 
 		self.audioTrackBtn.Bind(wx.EVT_BUTTON, self.onAudioTrack)
+		self.audioDeviceBtn.Bind(wx.EVT_BUTTON, self.onAudioDevice)
 		self.settingsBtn.Bind(wx.EVT_BUTTON, lambda event: SettingsDialog(self))
 		
 		# Player Controls Bindings
@@ -676,6 +680,43 @@ class MediaGui(wx.Frame):
 			rate = rates[idx]
 			self.player.media.set_rate(rate)
 			speak(choices[idx])
+		dlg.Destroy()
+
+	def onAudioDevice(self, event):
+		if not self.player: return
+		
+		# Get Devices
+		devices = self.player.get_audio_output_devices()
+		# Format: [{'id': ..., 'name': ...}, ...]
+		
+		if not devices:
+			speak(_("No audio devices found"))
+			return
+			
+		choices = [d['name'] for d in devices]
+		ids = [d['id'] for d in devices]
+		
+		# Find current selection index
+		current_id = config_get("audio_device")
+		selection = 0
+		if current_id in ids:
+			selection = ids.index(current_id)
+			
+		dlg = wx.SingleChoiceDialog(self, _("Select Audio Output Device"), _("Audio Device"), choices)
+		dlg.SetSelection(selection)
+		
+		if dlg.ShowModal() == wx.ID_OK:
+			idx = dlg.GetSelection()
+			new_id = ids[idx]
+			
+			# Apply to Player
+			self.player.set_audio_output_device(new_id)
+			
+			# Save setting
+			config_set("audio_device", new_id)
+			
+			speak(_("Audio device changed to {}").format(choices[idx]))
+			
 		dlg.Destroy()
 
 	@has_player


### PR DESCRIPTION
Added an 'Audio Device' button in the media player GUI, allowing users to select and apply audio output devices directly. Updated settings dialog to apply audio device changes immediately if possible, improving user experience without requiring a restart.